### PR TITLE
Check for streamURL in webcam settings

### DIFF
--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -645,7 +645,7 @@ class OctoPrintOutputDevice(PrinterOutputDevice):
                     if "feature" in json_data:
                         self._sd_supported = json_data["feature"]["sdSupport"]
 
-                    if "webcam" in json_data:
+                    if "webcam" in json_data and "streamURL" in json_data["webcam"]:
                         self._camera_shares_proxy = False
                         stream_url = json_data["webcam"]["streamUrl"]
                         if stream_url == "":


### PR DESCRIPTION
Insure that that there is a URL for the webcam stream in the returned JSON data from OctoPrint. OctoPrint 1.34 appears to return a webcam entry even though there is not a stream URL set in the settings. Without this check, the subsequent usage of stream_url will fail when streamURL is missing.